### PR TITLE
Migrate to new workspace format

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -11,7 +11,7 @@ use crate::term;
 
 
 fn path() -> Result<PathBuf> {
-    let path = paths::data_dir()?;
+    let path = paths::sn0int_dir()?;
     Ok(path.join("auth"))
 }
 

--- a/src/cmd/workspace_cmd.rs
+++ b/src/cmd/workspace_cmd.rs
@@ -53,6 +53,8 @@ fn usage(workspace: Option<Workspace>) -> Result<()> {
 }
 
 fn change(rl: &mut Shell, workspace: Workspace) -> Result<()> {
+    workspace.migrate()?;
+
     let blobs = BlobStorage::workspace(&workspace)?;
     let db = Database::establish(workspace)?;
     rl.set_blobstorage(blobs);

--- a/src/keyring.rs
+++ b/src/keyring.rs
@@ -74,7 +74,7 @@ pub struct KeyRing {
 
 impl KeyRing {
     pub fn path() -> Result<PathBuf> {
-        let path = paths::data_dir()?;
+        let path = paths::sn0int_dir()?;
         let path = path.join("keyring.json");
         Ok(path)
     }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::path::PathBuf;
 
 
-pub fn data_dir() -> Result<PathBuf> {
+pub fn sn0int_dir() -> Result<PathBuf> {
     let path = dirs::data_dir()
         .ok_or_else(|| format_err!("Failed to find data directory"))?;
     let path = path.join("sn0int");
@@ -16,24 +16,39 @@ pub fn data_dir() -> Result<PathBuf> {
 }
 
 pub fn history_path() -> Result<PathBuf> {
-    let path = data_dir()?;
+    let path = sn0int_dir()?;
     let path = path.join("history");
     Ok(path)
 }
 
 pub fn module_dir() -> Result<PathBuf> {
-    let path = data_dir()?;
+    let path = sn0int_dir()?;
     let path = path.join("modules");
     fs::create_dir_all(&path)
         .context("Failed to create module directory")?;
     Ok(path)
 }
 
+pub fn data_dir() -> Result<PathBuf> {
+    let path = sn0int_dir()?
+        .join("data");
+    fs::create_dir_all(&path)
+        .context("Failed to create module directory")?;
+    Ok(path)
+}
+
+pub fn workspace_dir(workspace: &Workspace) -> Result<PathBuf> {
+    let path = sn0int_dir()?
+        .join("data")
+        .join(workspace.as_str());
+    fs::create_dir_all(&path)
+        .context("Failed to create module directory")?;
+    Ok(path)
+}
+
 pub fn blobs_dir(workspace: &Workspace) -> Result<PathBuf> {
-    let path = data_dir()?;
-    let path = path
-        .join("blobs")
-        .join(workspace.to_string());
+    let path = workspace_dir(workspace)?
+        .join("blobs");
     fs::create_dir_all(&path)
         .context("Failed to create module directory")?;
     Ok(path)

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -477,6 +477,8 @@ pub fn init<'a>(args: &Args, config: &'a Config, verbose_init: bool) -> Result<S
         None => Workspace::from_str("default").unwrap(),
     };
 
+    workspace.migrate()?;
+
     let blobs = BlobStorage::workspace(&workspace)?;
     let db = if verbose_init {
         Database::establish(workspace)?

--- a/src/update.rs
+++ b/src/update.rs
@@ -26,7 +26,7 @@ pub struct AutoUpdater {
 impl AutoUpdater {
     #[inline]
     fn path() -> Result<PathBuf> {
-        let path = paths::data_dir()?;
+        let path = paths::sn0int_dir()?;
         Ok(path.join("autoupdate.json"))
     }
 


### PR DESCRIPTION
This migrates from:
```
~/.local/share/sn0int/foo.db
~/.local/share/sn0int/blobs/foo/
```
to
```
~/.local/share/sn0int/data/foo/db.sqlite
~/.local/share/sn0int/data/foo/blobs/
```
There's some code included to transparently do the migration when a workspace is activated. This code is going to be removed after the next few releases, all workspaces that haven't been migrated until then need to be migrated manually.