### PR TITLE
Automate homebrew formula upgrade process

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,17 @@
+name: homebrew
+
+on:
+  push:
+    tags: 'v*'
+
+jobs:
+  homebrew:
+    name: Bump Homebrew formula
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mislav/bump-homebrew-formula-action@v1
+        with:
+          # A PR will be sent to github.com/Homebrew/homebrew-core to update this formula:
+          formula-name: sn0int
+        env:
+          COMMITTER_TOKEN: ${{ secrets.COMMITTER_TOKEN }}


### PR DESCRIPTION
👋  homebrew-core maintainer in here, want to add this awesome github action to help you automate the homebrew release process.

One thing that you need to do on your end is to create a COMMITTER_TOKEN and put into github secrets settings page.

ref: https://github.com/marketplace/actions/bump-homebrew-formula