### PR TITLE
Add install details for Fedora/RH based systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ For everything else please have a look at the [detailed list][1].
   - [Archlinux](https://sn0int.readthedocs.io/en/latest/install.html#archlinux)
   - [Mac OSX](https://sn0int.readthedocs.io/en/latest/install.html#mac-osx)
   - [Debian/Ubuntu/Kali](https://sn0int.readthedocs.io/en/latest/install.html#debian-ubuntu-kali)
+  - [Fedora/CentOS/Redhat](https://sn0int.readthedocs.io/en/latest/install.html#fedora-centos-redhat)
   - [Docker](https://sn0int.readthedocs.io/en/latest/install.html#docker)
   - [Alpine](https://sn0int.readthedocs.io/en/latest/install.html#alpine)
   - [OpenBSD](https://sn0int.readthedocs.io/en/latest/install.html#openbsd)

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -37,6 +37,20 @@ at the docker image as an alternative.
     $ cd sn0int
     $ cargo install -f --path .
 
+Fedora/CentOS/Redhat
+--------------------
+
+Using rust+cargo from the repos might work for you, but we only officially
+support rust+cargo installed with `rustup <https://rustup.rs/>`_. Have a look
+at the docker image as an alternative.
+
+.. code-block:: bash
+
+    $ dnf install @development-tools libsq3-devel libseccomp-devel libsodium-devel publicsuffix-list
+    $ git clone https://github.com/kpcyrd/sn0int.git
+    $ cd sn0int
+    $ cargo install -f --path .
+
 Docker
 ------
 


### PR DESCRIPTION
Added notes from my install onto Fedora (23).  This is not a fresh distro install and so there is some assumption that I've needed to install `@development-tools` & `publicsuffix-list`.