### PR TITLE
Mention pkg-config being needed.

### DIFF
--- a/docs/build.rst
+++ b/docs/build.rst
@@ -32,7 +32,7 @@ Debian/Ubuntu/Kali
 
 .. code-block:: bash
 
-    $ apt install build-essential libsqlite3-dev libseccomp-dev libsodium-dev publicsuffix
+    $ apt install build-essential libsqlite3-dev libseccomp-dev libsodium-dev publicsuffix pkg-config
 
 .. warning::
    On a debian based system make sure you've installed rust with rustup.


### PR DESCRIPTION
Not all installations have build tools installed, and libsodium requires
calling out to pkg-config so add it to the build instructions on Debian
so that the build doesn't fail.