### PR TITLE
Support invoking shell commands with `!` from readline

### DIFF
--- a/src/args.rs
+++ b/src/args.rs
@@ -9,7 +9,7 @@ use sn0int_common::ModuleID;
 #[structopt(global_settings = &[AppSettings::ColoredHelp])]
 pub struct Args {
     /// Select a different workspace instead of the default
-    #[structopt(short="w", long="workspace")]
+    #[structopt(short="w", long="workspace", env="SN0INT_WORKSPACE")]
     pub workspace: Option<Workspace>,
 
     #[structopt(subcommand)]


### PR DESCRIPTION
This makes it easier to execute modules that need --stdin:

```
[sn0int][default] > !sudo arp-scan -qglI wlan0 | sn0int run --stdin kpcyrd/arp-scan -o network=home
[*] kpcyrd/arp-scan                                   : Adding device "00:11:22:33:44:55"
[*] kpcyrd/arp-scan                                   : Adding network-device "home+00:11:22:33:44:55"
[+] Finished kpcyrd/arp-scan
[sn0int][default] >
```

If you spawn child sn0int processes they're going to operate on your currently selected workspace (unless you pass `-w different-workspace` explicitly).