### PR TITLE
Fixed a typo

### DIFF
--- a/src/cmd/workspace_cmd.rs
+++ b/src/cmd/workspace_cmd.rs
@@ -11,7 +11,7 @@ use crate::workspaces::{self, Workspace};
 
 #[derive(Debug, Parser)]
 pub struct Args {
-    /// Delete a workspaceb
+    /// Delete a workspace
     #[arg(long = "delete", group = "action")]
     delete: bool,
     /// Show disk usage of workspace


### PR DESCRIPTION
I'm so sorry for making a pull request that is only one letter different, but this typo was really bugging me.

Changed "workspaceb" to "workspace" for the --delete command in `workspace -help`
![1738289348](https://github.com/user-attachments/assets/30518b88-b314-4281-b6da-a76dae0e863e)
